### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -3,6 +3,9 @@ name: Run tests and upload coverage
 on: 
   push
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run tests and collect coverage


### PR DESCRIPTION
Potential fix for [https://github.com/Qredence/AgenticFleet/security/code-scanning/10](https://github.com/Qredence/AgenticFleet/security/code-scanning/10)

To fix the issue, add a `permissions` block to the workflow file to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow only needs to read repository contents and upload coverage results, the `contents: read` permission is sufficient. This change should be applied at the root level of the workflow to cover all jobs unless specific jobs require additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
