### PR TITLE
Potential fix for code scanning alert no. 36: Log Injection

### DIFF
--- a/src/agenticfleet/cli/repl.py
+++ b/src/agenticfleet/cli/repl.py
@@ -30,7 +30,8 @@ async def run_repl() -> None:
             if not user_input:
                 continue
 
-            logger.info(f"Processing: '{user_input}'")
+            safe_user_input = user_input.replace('\r', '').replace('\n', '')
+            logger.info(f"Processing: '{safe_user_input}'")
             print("-" * 50)
 
             try:


### PR DESCRIPTION
Potential fix for [https://github.com/Qredence/AgenticFleet/security/code-scanning/36](https://github.com/Qredence/AgenticFleet/security/code-scanning/36)

To prevent log injection, all user input that is logged must be sanitized to remove line breaks and other characters that could adversely affect log parsing or display. The best practice is to replace `\r` and `\n` with empty strings before including user data in a log entry. This change should be performed just before logging on line 33—either by using a cleaned variable or directly inline. No additional dependencies are required for this simple sanitization. Only the line that constructs the log message with user input needs to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
