### PR TITLE
Potential fix for code scanning alert no. 35: Uncontrolled data used in path expression

### DIFF
--- a/src/agenticfleet/core/logging.py
+++ b/src/agenticfleet/core/logging.py
@@ -37,7 +37,11 @@ def setup_logging(
         log_path = (logs_root / safe_filename).resolve()
         # Final containment check
         try:
-            inside_logs = log_path.is_relative_to(logs_root) if hasattr(log_path, "is_relative_to") else str(log_path).startswith(str(logs_root))
+            inside_logs = (
+                log_path.is_relative_to(logs_root)
+                if hasattr(log_path, "is_relative_to")
+                else os.path.commonpath([str(log_path), str(logs_root)]) == str(logs_root)
+            )
         except Exception:
             inside_logs = False
         if not inside_logs:


### PR DESCRIPTION
Potential fix for [https://github.com/Qredence/AgenticFleet/security/code-scanning/35](https://github.com/Qredence/AgenticFleet/security/code-scanning/35)

To fix this issue, log file paths supplied via user input (e.g., the `LOG_FILE` environment variable) should be validated before being used in file and directory creation or writing. Since the code is intended to allow specifying a custom log file, the best general approach is to ensure the provided log file path is resolved to a location within a safe application-defined root directory (such as `logs/`). To do this:
- Define a safe log root directory (for example, using the default `logs/`).
- When a log file path is provided, combine it with the root and normalize the result with `os.path.normpath` or `.resolve()` (from `pathlib.Path`).
- Verify that the resolved path is inside the root directory using `Path.is_relative_to()` (Python 3.9+) or equivalent logic.
- If the check fails, raise an error or fall back to a safe default.

Changes should be made to `setup_logging` in `src/agenticfleet/core/logging.py` where the untrusted value is used. Necessary imports for any additional logic (e.g., for exceptions) should be added as needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
