### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/Qredence/agentic-fleet/security/code-scanning/17](https://github.com/Qredence/agentic-fleet/security/code-scanning/17)

To fix this, add a `permissions` block to the workflow file, ideally at the root level (so it applies to all jobs unless overridden), assigning the least privileges required. For the majority of workflows, `contents: read` is sufficient for checking out code and uploading/downloading artifacts. If any job requires elevated permissions (such as writing to issues or pull requests), those can be added as needed. 

In `.github/workflows/ci.yml`, add the following block directly under the workflow `name` (after line 1):
```yaml
permissions:
  contents: read
```
This ensures all jobs only receive read-only access to repository contents via GITHUB_TOKEN. No further imports or methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
