### PR TITLE
Potential fix for code scanning alert no. 140: Log Injection

### DIFF
--- a/src/agentic_fleet/utils/self_improvement.py
+++ b/src/agentic_fleet/utils/self_improvement.py
@@ -95,7 +95,7 @@ class SelfImprovementEngine:
         high_quality = self._filter_high_quality_executions(executions)
 
         logger.info(
-            f"Found {len(high_quality)} high-quality executions (score >= {self.min_quality_score})"
+            f"Found {len(high_quality)} high-quality executions (score >= {_sanitize_for_log(str(self.min_quality_score))})"
         )
 
         if not high_quality:


### PR DESCRIPTION
Potential fix for [https://github.com/Qredence/agentic-fleet/security/code-scanning/140](https://github.com/Qredence/agentic-fleet/security/code-scanning/140)

To fix the problem, all log entries that include user-controlled values—specifically, `self.min_quality_score`—should sanitize that value before including it in logs. Fortunately, this codebase contains a utility method, `_sanitize_for_log`, designed for this purpose. We should use this function to sanitize any data derived from user input before it is emitted in logs.

For this specific issue, we only have to sanitize `self.min_quality_score` within the log message at line 98 of `src/agentic_fleet/utils/self_improvement.py`. This can be accomplished by explicitly passing `str(self.min_quality_score)` through `_sanitize_for_log()` before including it in the log message. There is no need to sanitize values like `len(high_quality)`, as these are internally computed.

No new dependencies or imports are required, since `_sanitize_for_log` is already defined in the same file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
