### PR TITLE
Fix for Empty except

### DIFF
--- a/src/agentic_fleet/utils/compiler.py
+++ b/src/agentic_fleet/utils/compiler.py
@@ -629,7 +629,7 @@ def save_compiled_module(module: Any, filepath: str) -> str:
         if os.path.exists(tmp_path):
             os.remove(tmp_path)
     except Exception as e:
-        # Suppress errors if removing the temp file fails (e.g., if file doesn't exist or is locked).
+        # Suppress errors if removing the temp file fails (e.g., permission or locking issues).
         logger.warning(f"Failed to remove existing temp file {tmp_path}: {e}")
 
     strategies = [


### PR DESCRIPTION
To fix the issue, we should add a brief explanatory comment above or beside the `except Exception:` clause to clarify why exceptions are intentionally ignored here. Alternatively, we could log the exception to help with troubleshooting. Logging is preferable as it preserves error information for future debugging, while a comment is minimally sufficient.

The change should be restricted to the relevant `except Exception:` block on line 630 of `src/agentic_fleet/utils/compiler.py`. If logging is appropriate, we can add a logger statement (e.g., `logger.warning(...)`) to record the failure to remove the tempfile, but clarify that the operation will continue regardless.

No new imports are needed—the `logger` is already available.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._